### PR TITLE
Log build gradle path for failure messages

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -58,7 +58,7 @@ async function main(): Promise<void> {
         setEnvironmentVariable('ANDROID_VERSION_CODE', code);
         core.info(`Exposing ANDROID_VERSION_CODE with this value: ${code}.`);
       } else {
-        failWithMessage('Version code could not be found in the file');
+        failWithMessage(`Version code could not be found in the file: ${buildGradlePath}`);
 
       }
     }
@@ -69,7 +69,7 @@ async function main(): Promise<void> {
         setEnvironmentVariable('ANDROID_VERSION_NAME', name);
         core.info(`Exposing ANDROID_VERSION_NAME with this value: ${name}.`);
       } else {
-        failWithMessage('Version name could not be found in the file');
+        failWithMessage(`Version name could not be found in the file: ${buildGradlePath}`);
       }
     }
 


### PR DESCRIPTION
Log the path for a failed version code and version name search. This will help give insight into what file is been searched for the failed version name and code.